### PR TITLE
bundle_install attribute git_ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ will only be triggered if a gem is actually installed.
 * `vendor` – Enable local vendoring. This maps to the `--path` option in bundler,
   but that attribute name is already used.
 * `without` – Group or groups to not install.
+* `git_ssh` - GIT_SSH environment variable content.
 
 ## Ruby Providers
 

--- a/lib/poise_ruby/resources/bundle_install.rb
+++ b/lib/poise_ruby/resources/bundle_install.rb
@@ -82,6 +82,10 @@ module PoiseRuby
         #   Group or groups to not install.
         #   @return [String, Array<String>]
         attribute(:without, kind_of: [Array, String])
+        # @!attribute git_ssh
+        #   Value for GIT_SSH environment variable
+        #   @return [String]
+        attribute(:git_ssh, kind_of: [String])
 
         # The path to the `bundle` binary for this installation. This is an
         # output property.
@@ -157,7 +161,9 @@ module PoiseRuby
         # Install the gems in the Gemfile.
         def run_bundler(command)
           return converge_by "Run bundle #{command}" if whyrun_mode?
-          cmd = ruby_shell_out!(bundler_command(command), environment: {'BUNDLE_GEMFILE' => gemfile_path}, user: new_resource.user)
+          environment = { 'BUNDLE_GEMFILE' => gemfile_path }
+          environment['GIT_SSH'] = new_resource.git_ssh if new_resource.git_ssh
+          cmd = ruby_shell_out!(bundler_command(command), environment: environment, user: new_resource.user)
           # Look for a line like 'Installing $gemname $version' to know if we did anything.
           if cmd.stdout.include?('Installing')
             new_resource.updated_by_last_action(true)


### PR DESCRIPTION
New attribute git_ssh for resource bundle_install: if present, set GIT_SSH environment variable, allowing to install gems from private git repos.